### PR TITLE
Allow using librseq APIs from C++ code

### DIFF
--- a/include/rseq/rseq.h
+++ b/include/rseq/rseq.h
@@ -44,8 +44,16 @@
 #define RSEQ_INJECT_FAILED
 #endif
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 extern __thread struct rseq __rseq_abi;
 extern int __rseq_handled;
+
+#if defined(__cplusplus)
+}
+#endif
 
 #define rseq_likely(x)		__builtin_expect(!!(x), 1)
 #define rseq_unlikely(x)	__builtin_expect(!!(x), 0)
@@ -82,6 +90,10 @@ extern int __rseq_handled;
 #include <rseq/rseq-s390.h>
 #else
 #error unsupported target
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
 #endif
 
 /*
@@ -162,5 +174,9 @@ static inline void rseq_prepare_unload(void)
 {
 	rseq_clear_rseq_cs();
 }
+
+#if defined(__cplusplus)
+}
+#endif
 
 #endif  /* RSEQ_H_ */


### PR DESCRIPTION
If you call librseq APIs like rseq_available and rseq_register_current_thread from C++ code, linking fails:

    rseq.cpp:365: undefined reference to `rseq_available()'
    rseq.cpp:46: undefined reference to `rseq_register_current_thread()'

Tell the C++ compiler to treat librseq's exported APIs as having C mangling, fixing these linker errors.