### PR TITLE
fix: `void*` arithmetic compiler warning

### DIFF
--- a/src/rseq.c
+++ b/src/rseq.c
@@ -16,6 +16,7 @@
 #include <limits.h>
 #include <dlfcn.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #include <rseq/rseq.h>
 
@@ -134,7 +135,7 @@ void rseq_init(void)
 	if (!rseq_available(RSEQ_AVAILABLE_QUERY_KERNEL))
 		goto unlock;
 	rseq_ownership = 1;
-	rseq_offset = (void *)&__rseq_abi - rseq_thread_pointer();
+	rseq_offset = (uintptr_t)&__rseq_abi - (uintptr_t)rseq_thread_pointer();
 	rseq_size = sizeof(struct rseq_abi);
 	rseq_flags = 0;
 unlock:


### PR DESCRIPTION
Fixes the following compiler warning:
```bash
-- The C compiler identification is GNU 11.3.0
-- The CXX compiler identification is GNU 11.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- 
-- Looking for include file linux/rseq.h
-- Looking for include file linux/rseq.h - found
-- Performing Test HAVE_RSEQ_CID_FIELD
-- Performing Test HAVE_RSEQ_CID_FIELD - Failed
-- Looking for sched_getaffinity
-- Looking for sched_getaffinity - found
-- 
-- Library base name     : demo-alloc-debug
-- 
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Found OpenMP_C: -fopenmp (found version "4.5") 
-- Found OpenMP_CXX: -fopenmp (found version "4.5") 
-- Found OpenMP: TRUE (found version "4.5")  
-- 
-- Build type            : Debug
-- C Compiler exec       : /usr/bin/cc
-- C++ Compiler exec     : /usr/bin/c++
-- 
-- Configuring done
-- Generating done
-- Build files have been written to: /home/user/repos/mem-alloc/ccache-alloc/protos/demo-alloc/build
[  5%] Building C object src/CMakeFiles/librseq.dir/__/_deps/librseq-src/src/rseq.c.o
/home/user/repos/mem-alloc/ccache-alloc/protos/demo-alloc/build/_deps/librseq-src/src/rseq.c: In function ‘rseq_init’:
/home/user/repos/mem-alloc/ccache-alloc/protos/demo-alloc/build/_deps/librseq-src/src/rseq.c:137:43: warning: pointer of type ‘void *’ used in subtraction [-Wpointer-arith]
  137 |         rseq_offset = (void *)&__rseq_abi - rseq_thread_pointer();
      |                                           ^
[  5%] Built target librseq
[...]
```


---
Compiler: gcc 11.3.0
Platform: Ubuntu 22.04 Linux 6.3.0 RC7 x86-64

NOTE: Warnings are set to pedantic