### PR TITLE
fix: Compiler warnings `-Wswitch-default` & `-Wswitch-enum`

### DIFF
--- a/include/rseq/rseq.h
+++ b/include/rseq/rseq.h
@@ -369,6 +369,10 @@ int rseq_cmpeqv_trystorev_storev(enum rseq_mo rseq_mo, enum rseq_percpu_mode per
 				default:
 					return -1;
 			}
+		case RSEQ_MO_ACQUIRE:
+		case RSEQ_MO_ACQ_REL:
+		case RSEQ_MO_CONSUME:
+		case RSEQ_MO_SEQ_CST:
 		default:
 			return -1;
 	}
@@ -417,6 +421,10 @@ int rseq_cmpeqv_trymemcpy_storev(enum rseq_mo rseq_mo, enum rseq_percpu_mode per
 				default:
 					return -1;
 			}
+		case RSEQ_MO_ACQUIRE:
+		case RSEQ_MO_ACQ_REL:
+		case RSEQ_MO_CONSUME:
+		case RSEQ_MO_SEQ_CST:
 		default:
 			return -1;
 	}

--- a/include/rseq/rseq.h
+++ b/include/rseq/rseq.h
@@ -276,12 +276,13 @@ int rseq_cmpeqv_storev(enum rseq_mo rseq_mo, enum rseq_percpu_mode percpu_mode,
 	if (rseq_mo != RSEQ_MO_RELAXED)
 		return -1;
 	switch (percpu_mode) {
-	case RSEQ_PERCPU_CPU_ID:
-		return rseq_cmpeqv_storev_relaxed_cpu_id(v, expect, newv, cpu);
-	case RSEQ_PERCPU_MM_CID:
-		return rseq_cmpeqv_storev_relaxed_mm_cid(v, expect, newv, cpu);
+		case RSEQ_PERCPU_CPU_ID:
+			return rseq_cmpeqv_storev_relaxed_cpu_id(v, expect, newv, cpu);
+		case RSEQ_PERCPU_MM_CID:
+			return rseq_cmpeqv_storev_relaxed_mm_cid(v, expect, newv, cpu);
+		default:
+			return -1;
 	}
-	return -1;
 }
 
 /*
@@ -296,12 +297,13 @@ int rseq_cmpnev_storeoffp_load(enum rseq_mo rseq_mo, enum rseq_percpu_mode percp
 	if (rseq_mo != RSEQ_MO_RELAXED)
 		return -1;
 	switch (percpu_mode) {
-	case RSEQ_PERCPU_CPU_ID:
-		return rseq_cmpnev_storeoffp_load_relaxed_cpu_id(v, expectnot, voffp, load, cpu);
-	case RSEQ_PERCPU_MM_CID:
-		return rseq_cmpnev_storeoffp_load_relaxed_mm_cid(v, expectnot, voffp, load, cpu);
+		case RSEQ_PERCPU_CPU_ID:
+			return rseq_cmpnev_storeoffp_load_relaxed_cpu_id(v, expectnot, voffp, load, cpu);
+		case RSEQ_PERCPU_MM_CID:
+			return rseq_cmpnev_storeoffp_load_relaxed_mm_cid(v, expectnot, voffp, load, cpu);
+		default:
+			return -1;
 	}
-	return -1;
 }
 
 static inline __attribute__((always_inline))
@@ -311,12 +313,13 @@ int rseq_addv(enum rseq_mo rseq_mo, enum rseq_percpu_mode percpu_mode,
 	if (rseq_mo != RSEQ_MO_RELAXED)
 		return -1;
 	switch (percpu_mode) {
-	case RSEQ_PERCPU_CPU_ID:
-		return rseq_addv_relaxed_cpu_id(v, count, cpu);
-	case RSEQ_PERCPU_MM_CID:
-		return rseq_addv_relaxed_mm_cid(v, count, cpu);
+		case RSEQ_PERCPU_CPU_ID:
+			return rseq_addv_relaxed_cpu_id(v, count, cpu);
+		case RSEQ_PERCPU_MM_CID:
+			return rseq_addv_relaxed_mm_cid(v, count, cpu);
+		default:
+			return -1;
 	}
-	return -1;
 }
 
 #ifdef RSEQ_ARCH_HAS_OFFSET_DEREF_ADDV
@@ -331,12 +334,13 @@ int rseq_offset_deref_addv(enum rseq_mo rseq_mo, enum rseq_percpu_mode percpu_mo
 	if (rseq_mo != RSEQ_MO_RELAXED)
 		return -1;
 	switch (percpu_mode) {
-	case RSEQ_PERCPU_CPU_ID:
-		return rseq_offset_deref_addv_relaxed_cpu_id(ptr, off, inc, cpu);
-	case RSEQ_PERCPU_MM_CID:
-		return rseq_offset_deref_addv_relaxed_mm_cid(ptr, off, inc, cpu);
+		case RSEQ_PERCPU_CPU_ID:
+			return rseq_offset_deref_addv_relaxed_cpu_id(ptr, off, inc, cpu);
+		case RSEQ_PERCPU_MM_CID:
+			return rseq_offset_deref_addv_relaxed_mm_cid(ptr, off, inc, cpu);
+		default:
+			return -1;
 	}
-	return -1;
 }
 #endif
 
@@ -347,24 +351,26 @@ int rseq_cmpeqv_trystorev_storev(enum rseq_mo rseq_mo, enum rseq_percpu_mode per
 				 intptr_t newv, int cpu)
 {
 	switch (rseq_mo) {
-	case RSEQ_MO_RELAXED:
-		switch (percpu_mode) {
-		case RSEQ_PERCPU_CPU_ID:
-			return rseq_cmpeqv_trystorev_storev_relaxed_cpu_id(v, expect, v2, newv2, newv, cpu);
-		case RSEQ_PERCPU_MM_CID:
-			return rseq_cmpeqv_trystorev_storev_relaxed_mm_cid(v, expect, v2, newv2, newv, cpu);
-		}
-		return -1;
-	case RSEQ_MO_RELEASE:
-		switch (percpu_mode) {
-		case RSEQ_PERCPU_CPU_ID:
-			return rseq_cmpeqv_trystorev_storev_release_cpu_id(v, expect, v2, newv2, newv, cpu);
-		case RSEQ_PERCPU_MM_CID:
-			return rseq_cmpeqv_trystorev_storev_release_mm_cid(v, expect, v2, newv2, newv, cpu);
-		}
-		return -1;
-	default:
-		return -1;
+		case RSEQ_MO_RELAXED:
+			switch (percpu_mode) {
+				case RSEQ_PERCPU_CPU_ID:
+					return rseq_cmpeqv_trystorev_storev_relaxed_cpu_id(v, expect, v2, newv2, newv, cpu);
+				case RSEQ_PERCPU_MM_CID:
+					return rseq_cmpeqv_trystorev_storev_relaxed_mm_cid(v, expect, v2, newv2, newv, cpu);
+				default:
+					return -1;
+			}
+		case RSEQ_MO_RELEASE:
+			switch (percpu_mode) {
+				case RSEQ_PERCPU_CPU_ID:
+					return rseq_cmpeqv_trystorev_storev_release_cpu_id(v, expect, v2, newv2, newv, cpu);
+				case RSEQ_PERCPU_MM_CID:
+					return rseq_cmpeqv_trystorev_storev_release_mm_cid(v, expect, v2, newv2, newv, cpu);
+				default:
+					return -1;
+			}
+		default:
+			return -1;
 	}
 }
 
@@ -377,12 +383,13 @@ int rseq_cmpeqv_cmpeqv_storev(enum rseq_mo rseq_mo, enum rseq_percpu_mode percpu
 	if (rseq_mo != RSEQ_MO_RELAXED)
 		return -1;
 	switch (percpu_mode) {
-	case RSEQ_PERCPU_CPU_ID:
-		return rseq_cmpeqv_cmpeqv_storev_relaxed_cpu_id(v, expect, v2, expect2, newv, cpu);
-	case RSEQ_PERCPU_MM_CID:
-		return rseq_cmpeqv_cmpeqv_storev_relaxed_mm_cid(v, expect, v2, expect2, newv, cpu);
+		case RSEQ_PERCPU_CPU_ID:
+			return rseq_cmpeqv_cmpeqv_storev_relaxed_cpu_id(v, expect, v2, expect2, newv, cpu);
+		case RSEQ_PERCPU_MM_CID:
+			return rseq_cmpeqv_cmpeqv_storev_relaxed_mm_cid(v, expect, v2, expect2, newv, cpu);
+		default:
+			return -1;
 	}
-	return -1;
 }
 
 static inline __attribute__((always_inline))
@@ -392,24 +399,26 @@ int rseq_cmpeqv_trymemcpy_storev(enum rseq_mo rseq_mo, enum rseq_percpu_mode per
 				 intptr_t newv, int cpu)
 {
 	switch (rseq_mo) {
-	case RSEQ_MO_RELAXED:
-		switch (percpu_mode) {
-		case RSEQ_PERCPU_CPU_ID:
-			return rseq_cmpeqv_trymemcpy_storev_relaxed_cpu_id(v, expect, dst, src, len, newv, cpu);
-		case RSEQ_PERCPU_MM_CID:
-			return rseq_cmpeqv_trymemcpy_storev_relaxed_mm_cid(v, expect, dst, src, len, newv, cpu);
-		}
-		return -1;
-	case RSEQ_MO_RELEASE:
-		switch (percpu_mode) {
-		case RSEQ_PERCPU_CPU_ID:
-			return rseq_cmpeqv_trymemcpy_storev_release_cpu_id(v, expect, dst, src, len, newv, cpu);
-		case RSEQ_PERCPU_MM_CID:
-			return rseq_cmpeqv_trymemcpy_storev_release_mm_cid(v, expect, dst, src, len, newv, cpu);
-		}
-		return -1;
-	default:
-		return -1;
+		case RSEQ_MO_RELAXED:
+			switch (percpu_mode) {
+				case RSEQ_PERCPU_CPU_ID:
+					return rseq_cmpeqv_trymemcpy_storev_relaxed_cpu_id(v, expect, dst, src, len, newv, cpu);
+				case RSEQ_PERCPU_MM_CID:
+					return rseq_cmpeqv_trymemcpy_storev_relaxed_mm_cid(v, expect, dst, src, len, newv, cpu);
+				default:
+					return -1;
+			}
+		case RSEQ_MO_RELEASE:
+			switch (percpu_mode) {
+				case RSEQ_PERCPU_CPU_ID:
+					return rseq_cmpeqv_trymemcpy_storev_release_cpu_id(v, expect, dst, src, len, newv, cpu);
+				case RSEQ_PERCPU_MM_CID:
+					return rseq_cmpeqv_trymemcpy_storev_release_mm_cid(v, expect, dst, src, len, newv, cpu);
+				default:
+					return -1;
+			}
+		default:
+			return -1;
 	}
 }
 


### PR DESCRIPTION
```
/home/user/repos/mem-alloc/ccache-alloc/protos/mem-alloc/build/_deps/librseq-src/include/rseq/rseq.h: In function ‘rseq_addv’:
/home/user/repos/mem-alloc/ccache-alloc/protos/mem-alloc/build/_deps/librseq-src/include/rseq/rseq.h:313:9: warning: switch missing default case [-Wswitch-default]
  313 |         switch (percpu_mode) {
      |         ^~~~~~
/home/user/repos/mem-alloc/ccache-alloc/protos/mem-alloc/build/_deps/librseq-src/include/rseq/rseq.h: In function ‘rseq_offset_deref_addv’:
/home/user/repos/mem-alloc/ccache-alloc/protos/mem-alloc/build/_deps/librseq-src/include/rseq/rseq.h:333:9: warning: switch missing default case [-Wswitch-default]
  333 |         switch (percpu_mode) {
      |         ^~~~~~
/home/user/repos/mem-alloc/ccache-alloc/protos/mem-alloc/build/_deps/librseq-src/include/rseq/rseq.h: In function ‘rseq_cmpeqv_trystorev_storev’:
/home/user/repos/mem-alloc/ccache-alloc/protos/mem-alloc/build/_deps/librseq-src/include/rseq/rseq.h:351:17: warning: switch missing default case [-Wswitch-default]
  351 |                 switch (percpu_mode) {
      |                 ^~~~~~
/home/user/repos/mem-alloc/ccache-alloc/protos/mem-alloc/build/_deps/librseq-src/include/rseq/rseq.h:359:17: warning: switch missing default case [-Wswitch-default]
  359 |                 switch (percpu_mode) {
      |                 ^~~~~~
/home/user/repos/mem-alloc/ccache-alloc/protos/mem-alloc/build/_deps/librseq-src/include/rseq/rseq.h:349:9: warning: enumeration value ‘RSEQ_MO_CONSUME’ not handled in switch [-Wswitch-enum]
  349 |         switch (rseq_mo) {
      |         ^~~~~~
/home/user/repos/mem-alloc/ccache-alloc/protos/mem-alloc/build/_deps/librseq-src/include/rseq/rseq.h:349:9: warning: enumeration value ‘RSEQ_MO_ACQUIRE’ not handled in switch [-Wswitch-enum]
/home/user/repos/mem-alloc/ccache-alloc/protos/mem-alloc/build/_deps/librseq-src/include/rseq/rseq.h:349:9: warning: enumeration value ‘RSEQ_MO_ACQ_REL’ not handled in switch [-Wswitch-enum]
/home/user/repos/mem-alloc/ccache-alloc/protos/mem-alloc/build/_deps/librseq-src/include/rseq/rseq.h:349:9: warning: enumeration value ‘RSEQ_MO_SEQ_CST’ not handled in switch [-Wswitch-enum]
/home/user/repos/mem-alloc/ccache-alloc/protos/mem-alloc/build/_deps/librseq-src/include/rseq/rseq.h: In function ‘rseq_cmpeqv_cmpeqv_storev’:
/home/user/repos/mem-alloc/ccache-alloc/protos/mem-alloc/build/_deps/librseq-src/include/rseq/rseq.h:379:9: warning: switch missing default case [-Wswitch-default]
  379 |         switch (percpu_mode) {
      |         ^~~~~~
/home/user/repos/mem-alloc/ccache-alloc/protos/mem-alloc/build/_deps/librseq-src/include/rseq/rseq.h: In function ‘rseq_cmpeqv_trymemcpy_storev’:
/home/user/repos/mem-alloc/ccache-alloc/protos/mem-alloc/build/_deps/librseq-src/include/rseq/rseq.h:396:17: warning: switch missing default case [-Wswitch-default]
  396 |                 switch (percpu_mode) {
      |                 ^~~~~~
/home/user/repos/mem-alloc/ccache-alloc/protos/mem-alloc/build/_deps/librseq-src/include/rseq/rseq.h:404:17: warning: switch missing default case [-Wswitch-default]
  404 |                 switch (percpu_mode) {
      |                 ^~~~~~
/home/user/repos/mem-alloc/ccache-alloc/protos/mem-alloc/build/_deps/librseq-src/include/rseq/rseq.h:394:9: warning: enumeration value ‘RSEQ_MO_CONSUME’ not handled in switch [-Wswitch-enum]
  394 |         switch (rseq_mo) {
      |         ^~~~~~
/home/user/repos/mem-alloc/ccache-alloc/protos/mem-alloc/build/_deps/librseq-src/include/rseq/rseq.h:394:9: warning: enumeration value ‘RSEQ_MO_ACQUIRE’ not handled in switch [-Wswitch-enum]
/home/user/repos/mem-alloc/ccache-alloc/protos/mem-alloc/build/_deps/librseq-src/include/rseq/rseq.h:394:9: warning: enumeration value ‘RSEQ_MO_ACQ_REL’ not handled in switch [-Wswitch-enum]
/home/user/repos/mem-alloc/ccache-alloc/protos/mem-alloc/build/_deps/librseq-src/include/rseq/rseq.h:394:9: warning: enumeration value ‘RSEQ_MO_SEQ_CST’ not handled in switch [-Wswitch-enum]
```


Observed on Ubuntu 22.04 LTS, gcc 11.3.0
Warnings were explicitly enabled: `-Wswitch-default` & `-Wswitch-enum`