### PR TITLE
Add arm64 headers to list of headers to be installed

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -9,6 +9,8 @@ nobase_include_HEADERS = \
 	rseq/rseq-bits-reset.h \
 	rseq/rseq-arm.h \
 	rseq/rseq-arm-bits.h \
+	rseq/rseq-arm64.h \
+	rseq/rseq-arm64-bits.h \
 	rseq/rseq-mips.h \
 	rseq/rseq-mips-bits.h \
 	rseq/rseq-ppc.h \


### PR DESCRIPTION
Currently these aren't being installed leading to compile failures on arm64 when trying to include rseq.h after a `make install`.